### PR TITLE
Parameter added for displaying only conflicting assembly references.

### DIFF
--- a/AsmSpy/Program.cs
+++ b/AsmSpy/Program.cs
@@ -10,7 +10,7 @@ namespace AsmSpy
     {
         static void Main(string[] args)
         {
-            if (args.Length != 1)
+            if (args.Length != 2 && args.Length != 1)
             {
                 PrintUsage();
                 return;
@@ -23,15 +23,18 @@ namespace AsmSpy
                 return;
             }
 
-            AnalyseAssemblies(new DirectoryInfo(directoryPath));
+
+            var onlyConflicts = args.Length == 2 ? (args[1] != "all") : true;
+
+            AnalyseAssemblies(new DirectoryInfo(directoryPath), onlyConflicts);
         }
 
-        public static void AnalyseAssemblies(DirectoryInfo directoryInfo)
+        public static void AnalyseAssemblies(DirectoryInfo directoryInfo, bool onlyConflicts)
         {
             var assemblyFiles = directoryInfo.GetFiles("*.dll").Concat(directoryInfo.GetFiles("*.exe"));
             if (!assemblyFiles.Any())
             {
-                Console.WriteLine("No dll files found in directory: '{0}'", 
+                Console.WriteLine("No dll files found in directory: '{0}'",
                     directoryInfo.FullName);
                 return;
             }
@@ -41,7 +44,7 @@ namespace AsmSpy
             Console.WriteLine("");
 
             var assemblies = new Dictionary<string, IList<ReferencedAssembly>>();
-            foreach (var fileInfo in assemblyFiles)
+            foreach (var fileInfo in assemblyFiles.OrderBy(asm => asm.Name))
             {
                 Assembly assembly = null;
                 try
@@ -65,12 +68,22 @@ namespace AsmSpy
                 }
             }
 
+            if (onlyConflicts)
+                Console.WriteLine("Detailing only conflicting assembly references.");
+
             foreach (var assembly in assemblies)
             {
                 Console.WriteLine("Reference: {0}", assembly.Key);
-                foreach (var referencedAssembly in assembly.Value)
+
+                IList<ReferencedAssembly> refAsm = new List<ReferencedAssembly>();
+
+                if (!onlyConflicts
+                    || (onlyConflicts && assembly.Value.GroupBy(x => x.VersionReferenced).Count() != 1))
                 {
-                    Console.WriteLine("\t{0} by {1}", referencedAssembly.VersionReferenced, referencedAssembly.ReferencedBy.GetName().Name);
+                    foreach (var referencedAssembly in assembly.Value)
+                    {
+                        Console.WriteLine("\t{0} by {1}", referencedAssembly.VersionReferenced, referencedAssembly.ReferencedBy.GetName().Name);
+                    }
                 }
             }
         }
@@ -83,9 +96,10 @@ namespace AsmSpy
         private static void PrintUsage()
         {
             Console.WriteLine("Usage:");
-            Console.WriteLine("AsmSpy <directory to load assemblies from>");
+            Console.WriteLine("AsmSpy <directory to load assemblies from> [all]");
             Console.WriteLine("E.g.");
             Console.WriteLine(@"AsmSpy C:\Source\My.Solution\My.Project\bin\Debug");
+            Console.WriteLine(@"AsmSpy C:\Source\My.Solution\My.Project\bin\Debug all");
         }
     }
 

--- a/AsmSpy/UnitTests.cs
+++ b/AsmSpy/UnitTests.cs
@@ -4,10 +4,16 @@ namespace AsmSpy
 {
     public class UnitTests
     {
+        public void AnalyseAssemblies_should_output_correct_info_only_conflicts()
+        {
+            const string path = @"D:\Source\sutekishop\Suteki.Shop\Suteki.Shop.CreateDb\bin\Debug";
+            Program.AnalyseAssemblies(new DirectoryInfo(path), true);
+        }
+
         public void AnalyseAssemblies_should_output_correct_info()
         {
             const string path = @"D:\Source\sutekishop\Suteki.Shop\Suteki.Shop.CreateDb\bin\Debug";
-            Program.AnalyseAssemblies(new DirectoryInfo(path));
+            Program.AnalyseAssemblies(new DirectoryInfo(path), false);
         }
     }
 }

--- a/README.txt
+++ b/README.txt
@@ -6,10 +6,15 @@ How it works:
 Simply run AsmSpy giving it a path to your bin directory (the folder where your project's assemblies live).
 
 E.G:
+AsmSpy D:\Source\sutekishop\Suteki.Shop\Suteki.Shop\bin all
+
+It will output a list of all the assemblies and assemblies referenced by your assemblies. You can look at the
+list to determine where versioining conflicts occur.
+
+E.G:
 AsmSpy D:\Source\sutekishop\Suteki.Shop\Suteki.Shop\bin
 
-It will output a list of all the assemblies referenced by your assemblies. You can look at the
-list to determine where versioining conflicts occur.
+It will output a list of all assemblies and only conflicting assembly references.
  
 The output looks something like this:
 


### PR DESCRIPTION
Hi, I added the following features.
- Parameter added for displaying only conflicting assembly references.
- Assembly names are ordered before printing.
