### PR TITLE
Assembly references are now alphabetically ordered.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,5 @@
 [Tt]humbs.db 
 _ReSharper.*
 .vs
+*.swp
+*.swo

--- a/AsmSpy/AsmSpy.csproj
+++ b/AsmSpy/AsmSpy.csproj
@@ -40,7 +40,7 @@
     <Reference Include="Microsoft.CSharp" />
   </ItemGroup>
   <ItemGroup>
-    <Compile Include="Native\FileInfoExtansions.cs" />
+    <Compile Include="Native\FileInfoExtensions.cs" />
     <Compile Include="Native\ImageDataDirectory.cs" />
     <Compile Include="Native\ImageDosHeader.cs" />
     <Compile Include="Native\ImageFileHeader.cs" />

--- a/AsmSpy/Native/FileInfoExtensions.cs
+++ b/AsmSpy/Native/FileInfoExtensions.cs
@@ -2,7 +2,7 @@
 
 namespace AsmSpy.Native
 {
-    internal static class FileInfoExtansions
+    internal static class FileInfoExtensions
     {
         internal static bool IsAssembly(this FileInfo fileInfo)
         {

--- a/AsmSpy/Program.cs
+++ b/AsmSpy/Program.cs
@@ -87,22 +87,24 @@ namespace AsmSpy
             if (onlyConflicts)
                 Console.WriteLine("Detailing only conflicting assembly references.");
 
-            foreach (var assembly in assemblies)
+            foreach (var assemblyName in assemblies.Keys.OrderBy(asm => asm, StringComparer.OrdinalIgnoreCase))
             {
-                if (skipSystem && (assembly.Key.StartsWith("System") || assembly.Key.StartsWith("mscorlib"))) continue;
+                var assemblyValue = assemblies[assemblyName];
+
+                if (skipSystem && (assemblyName.StartsWith("System") || assemblyName.StartsWith("mscorlib"))) continue;
 
                 if (!onlyConflicts
-                    || (onlyConflicts && assembly.Value.GroupBy(x => x.VersionReferenced).Count() != 1))
+                    || (onlyConflicts && assemblyValue.GroupBy(x => x.VersionReferenced).Count() != 1))
                 {
                     Console.ForegroundColor = ConsoleColor.White;
                     Console.Write("Reference: ");
                     Console.ForegroundColor = ConsoleColor.Gray;
-                    Console.WriteLine("{0}", assembly.Key);
+                    Console.WriteLine("{0}", assemblyName);
 
                     var referencedAssemblies = new List<Tuple<string, string>>();
                     var versionsList = new List<string>();
                     var asmList = new List<string>();
-                    foreach (var referencedAssembly in assembly.Value)
+                    foreach (var referencedAssembly in assemblyValue)
                     {
                         var s1 = referencedAssembly.VersionReferenced.ToString();
                         var s2 = referencedAssembly.ReferencedBy.GetName().Name;

--- a/AsmSpy/Program.cs
+++ b/AsmSpy/Program.cs
@@ -55,7 +55,7 @@ namespace AsmSpy
             Console.WriteLine(directoryInfo.FullName);
             Console.WriteLine("");
 
-            var assemblies = new Dictionary<string, IList<ReferencedAssembly>>();
+            var assemblies = new Dictionary<string, IList<ReferencedAssembly>>(StringComparer.OrdinalIgnoreCase);
             foreach (var fileInfo in assemblyFiles.OrderBy(asm => asm.Name))
             {
                 Assembly assembly = null;
@@ -87,24 +87,22 @@ namespace AsmSpy
             if (onlyConflicts)
                 Console.WriteLine("Detailing only conflicting assembly references.");
 
-            foreach (var assemblyName in assemblies.Keys.OrderBy(asm => asm, StringComparer.OrdinalIgnoreCase))
+            foreach (var assemblyReferences in assemblies.OrderBy(i => i.Key))
             {
-                var assemblyValue = assemblies[assemblyName];
-
-                if (skipSystem && (assemblyName.StartsWith("System") || assemblyName.StartsWith("mscorlib"))) continue;
+                if (skipSystem && (assemblyReferences.Key.StartsWith("System") || assemblyReferences.Key.StartsWith("mscorlib"))) continue;
 
                 if (!onlyConflicts
-                    || (onlyConflicts && assemblyValue.GroupBy(x => x.VersionReferenced).Count() != 1))
+                    || (onlyConflicts && assemblyReferences.Value.GroupBy(x => x.VersionReferenced).Count() != 1))
                 {
                     Console.ForegroundColor = ConsoleColor.White;
                     Console.Write("Reference: ");
                     Console.ForegroundColor = ConsoleColor.Gray;
-                    Console.WriteLine("{0}", assemblyName);
+                    Console.WriteLine("{0}", assemblyReferences.Key);
 
                     var referencedAssemblies = new List<Tuple<string, string>>();
                     var versionsList = new List<string>();
                     var asmList = new List<string>();
-                    foreach (var referencedAssembly in assemblyValue)
+                    foreach (var referencedAssembly in assemblyReferences.Value)
                     {
                         var s1 = referencedAssembly.VersionReferenced.ToString();
                         var s2 = referencedAssembly.ReferencedBy.GetName().Name;


### PR DESCRIPTION
I used it for a large project and having an alphabetically ordered list of assembly references made my life easier.