### PR TITLE
Simplified if onlyConflicts logic in Program.cs

### DIFF
--- a/AsmSpy/Program.cs
+++ b/AsmSpy/Program.cs
@@ -92,7 +92,8 @@ namespace AsmSpy
                 if (skipSystem && (assemblyReferences.Key.StartsWith("System") || assemblyReferences.Key.StartsWith("mscorlib"))) continue;
 
                 if (!onlyConflicts
-                    || (onlyConflicts && assemblyReferences.Value.GroupBy(x => x.VersionReferenced).Count() != 1))
+                    //|| (onlyConflicts && assemblyReferences.Value.GroupBy(x => x.VersionReferenced).Count() != 1))
+                    || assemblyReferences.Value.GroupBy(x => x.VersionReferenced).Count() != 1)
                 {
                     Console.ForegroundColor = ConsoleColor.White;
                     Console.Write("Reference: ");

--- a/AsmSpy/Program.cs
+++ b/AsmSpy/Program.cs
@@ -91,9 +91,7 @@ namespace AsmSpy
             {
                 if (skipSystem && (assemblyReferences.Key.StartsWith("System") || assemblyReferences.Key.StartsWith("mscorlib"))) continue;
 
-                if (!onlyConflicts
-                    //|| (onlyConflicts && assemblyReferences.Value.GroupBy(x => x.VersionReferenced).Count() != 1))
-                    || assemblyReferences.Value.GroupBy(x => x.VersionReferenced).Count() != 1)
+                if (!onlyConflicts || assemblyReferences.Value.GroupBy(x => x.VersionReferenced).Count() != 1)
                 {
                     Console.ForegroundColor = ConsoleColor.White;
                     Console.Write("Reference: ");


### PR DESCRIPTION
Hi - a simple change just to make the code a bit shorter taking out an unnecessary logic check.  No problems to leave as is if that is clearer.