### PR TITLE
Added chocolatey package nuspec and install scripts

### DIFF
--- a/chocolatey/asmspy.nuspec
+++ b/chocolatey/asmspy.nuspec
@@ -1,0 +1,27 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<!-- Do not remove this test for UTF-8: if “Ω” doesn’t appear as greek uppercase omega letter enclosed in quotation marks, you should use an editor that supports UTF-8, not this one. -->
+<package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
+  <metadata>
+    <!-- Read this before publishing packages to chocolatey.org: https://github.com/chocolatey/chocolatey/wiki/CreatePackages -->
+    <id>asmspy</id>
+    <title>AsmSpy (Install)</title>
+    <version>1.0.0</version>
+    <authors>Mike Hadlow</authors>
+    <owners>Mike Hadlow</owners>
+    <summary>Command line tool to view assembly references.</summary>
+    <description>AsmSpy is a Command line tool to view assembly references. It will output a list of all conflicting assembly references. That is where different assemblies in your bin folder reference different versions of the same assembly. 
+    </description>
+    <projectUrl>https://github.com/mikehadlow/AsmSpy</projectUrl>
+    <projectSourceUrl>https://github.com/mikehadlow/AsmSpy</projectSourceUrl>
+    <docsUrl>https://github.com/mikehadlow/AsmSpy/blob/master/README.md</docsUrl>
+    <bugTrackerUrl>https://github.com/mikehadlow/AsmSpy/issues</bugTrackerUrl>
+    <tags>asmspy console</tags>
+    <copyright>Copyright © 2016 Mike Hadlow</copyright>
+    <licenseUrl>https://github.com/mikehadlow/AsmSpy/blob/master/licence.txt</licenseUrl>
+    <requireLicenseAcceptance>false</requireLicenseAcceptance>
+    <releaseNotes>Publishing to Chocolatey</releaseNotes>
+  </metadata>
+  <files>
+    <file src="tools\**" target="tools" />
+  </files>
+</package>

--- a/chocolatey/tools/ReadMe.md
+++ b/chocolatey/tools/ReadMe.md
@@ -1,0 +1,91 @@
+﻿## Summary
+How do I create packages? See https://github.com/chocolatey/choco/wiki/CreatePackages
+
+If you are submitting packages to the community feed (https://chocolatey.org)
+always try to ensure you have read, understood and adhere to the create
+packages wiki link above.
+
+## Automatic Packages?
+Consider making this package an automatic package, for the best 
+maintainability over time. Read up at https://github.com/chocolatey/choco/wiki/AutomaticPackages
+
+## Shim Generation
+Any executables you include in the package or download (but don't call 
+install against using the built-in functions) will be automatically shimmed.
+
+This means those executables will automatically be included on the path.
+Shim generation runs whether the package is self-contained or uses automation 
+scripts. 
+
+By default, these are considered console applications. 
+
+If the application is a GUI, you should create an empty file next to the exe 
+named 'name.exe.gui' e.g. 'bob.exe' would need a file named 'bob.exe.gui'.
+See https://github.com/chocolatey/choco/wiki/CreatePackages#how-do-i-set-up-batch-redirects-for-applications-that-have-a-gui
+
+If you want to ignore the executable, create an empty file next to the exe 
+named 'name.exe.ignore' e.g. 'bob.exe' would need a file named 
+'bob.exe.ignore'. 
+See https://github.com/chocolatey/choco/wiki/CreatePackages#how-do-i-exclude-executables-from-getting-batch-redirects
+
+## Self-Contained? 
+If you have a self-contained package, you can remove the automation scripts 
+entirely and just include the executables, they will automatically get shimmed, 
+which puts them on the path. Ensure you have the legal right to distribute 
+the application though. See https://github.com/chocolatey/choco/wiki/Legal. 
+
+You should read up on the Shim Generation section to familiarize yourself 
+on what to do with GUI applications and/or ignoring shims.
+
+## Automation Scripts
+You have a powerful use of Chocolatey, as you are using PowerShell. So you
+can do just about anything you need. Choco has some very handy built-in 
+functions that you can use, these are sometimes called the helpers.
+
+### Built-In Functions
+https://github.com/chocolatey/choco/wiki/HelpersReference
+
+A note about a couple:
+* Get-BinRoot - this is a horribly named function that doesn't do what new folks think it does. It gets you the 'tools' root, which by default is set to 'c:\tools', not the chocolateyInstall bin folder. 
+* Install-BinFile - used for non-exe files - executables are automatically shimmed...
+* Uninstall-BinFile - used for non-exe files - executables are automatically shimmed
+
+### Getting package specific information
+Use the package parameters pattern - see https://github.com/chocolatey/choco/wiki/How-To-Parse-PackageParameters-Argument
+
+### Need to mount an ISO?
+https://github.com/chocolatey/choco/wiki/How-To-Mount-An-Iso-In-Chocolatey-Package
+
+
+### Environment Variables
+Chocolatey makes a number of environment variables available (You can access any of these with $env:TheVariableNameBelow):
+
+ * TEMP = Overridden to the CacheLocation, but may be the same as the original TEMP folder
+ * ChocolateyInstall = Top level folder where Chocolatey is installed
+ * chocolateyPackageName = The name of the package, equivalent to the id in the nuspec (0.9.9+)
+ * chocolateyPackageVersion = The version of the package, equivalent to the version in the nuspec (0.9.9+)
+ * chocolateyPackageFolder = The top level location of the package folder
+
+#### Advanced Environment Variables
+The following are more advanced settings:
+
+ * chocolateyPackageParameters = (0.9.8.22+)
+ * CHOCOLATEY_VERSION = The version of Choco you normally see. Use if you are 'lighting' things up based on choco version. (0.9.9+)
+    - Otherwise take a dependency on the specific version you need. 
+ * chocolateyForceX86 = If available and set to 'true', then user has requested 32bit version. (0.9.9+)
+    - Automatically handled in built in Choco functions. 
+ * OS_PLATFORM = Like Windows, OSX, Linux. (0.9.9+)
+ * OS_VERSION = The version of OS, like 6.1 something something for Windows. (0.9.9+)
+ * OS_NAME = The reported name of the OS. (0.9.9+)
+ * IS_PROCESSELEVATED = Is the process elevated? (0.9.9+)
+ 
+#### Experimental Environment Variables
+The following are experimental or use not recommended:
+
+ * OS_IS64BIT = This may not return correctly - it may depend on the process the app is running under (0.9.9+)
+ * CHOCOLATEY_VERSION_PRODUCT = the version of Choco that may match CHOCOLATEY_VERSION but may be different (0.9.9+)
+    - it's based on git describe
+ * IS_ADMIN = Is the user an administrator? But doesn't tell you if the process is elevated. (0.9.9+)
+ * chocolateyInstallOverride = Not for use in package automation scripts. (0.9.9+)
+ * chocolateyInstallArguments = the installer arguments meant for the native installer. You should use chocolateyPackageParameters intead. (0.9.9+)
+

--- a/chocolatey/tools/chocolateyinstall.ps1
+++ b/chocolatey/tools/chocolateyinstall.ps1
@@ -1,0 +1,17 @@
+﻿$ErrorActionPreference = 'Stop';
+
+
+$packageName = 'AsmSpy'
+$toolsDir = "$(Split-Path -parent $MyInvocation.MyCommand.Definition)"
+$url = 'http://static.mikehadlow.com/AsmSpy.zip' 
+
+$packageArgs = @{
+  packageName   = $packageName
+  unzipLocation = $toolsDir
+  fileType      = 'EXE' 
+  url           = $url
+  checksum      = '53d3e96213d8f453bc1b5cdbbfb39c78942efef4'
+  checksumType  = 'sha1' 
+}
+
+Install-ChocolateyZipPackage @packageArgs


### PR DESCRIPTION
Added in the nuspec file for chocolatey for fixing #14 . Feel free to add/edit the values as you feel.

Once you merge in you will have to create the package and push it to your [Chocolatey](https://chocolatey.org/packages/upload) account.
- Running [cpack](https://github.com/chocolatey/choco/wiki/CommandsPack) from the chocolatey folder will create the package
- Use [cpush](https://github.com/chocolatey/choco/wiki/CommandsPush) or the web UI to upload the package

***If you are regenerating the zip package, you might have to update the sha1 checksum value.***
 I used the certutil to generate it (just in case you needed it) *CertUtil -hashfile AsmSpy.zip sha1*