### PR TITLE
Seperated visualization from analyzing by using a Analyzer and Visual…

### DIFF
--- a/AsmSpy/AsmSpy.csproj
+++ b/AsmSpy/AsmSpy.csproj
@@ -40,6 +40,12 @@
     <Reference Include="Microsoft.CSharp" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="AssemblyReferenceInfo.cs" />
+    <Compile Include="ConsoleVisualizer.cs" />
+    <Compile Include="DependencyAnalyzer.cs" />
+    <Compile Include="DependencyAnalyzerReport.cs" />
+    <Compile Include="IDependencyAnalyzer.cs" />
+    <Compile Include="IDependencyVisualizer.cs" />
     <Compile Include="Native\FileInfoExtensions.cs" />
     <Compile Include="Native\ImageDataDirectory.cs" />
     <Compile Include="Native\ImageDosHeader.cs" />
@@ -51,7 +57,6 @@
     <Compile Include="Native\MachineType.cs" />
     <Compile Include="Program.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
-    <Compile Include="UnitTests.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 

--- a/AsmSpy/AssemblyReferenceInfo.cs
+++ b/AsmSpy/AssemblyReferenceInfo.cs
@@ -1,0 +1,74 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Text;
+
+namespace AsmSpy
+{
+    public class AssemblyReferenceInfo
+    {
+        #region Fields
+
+        HashSet<AssemblyReferenceInfo> _References = new HashSet<AssemblyReferenceInfo>();
+        HashSet<AssemblyReferenceInfo> _ReferencedBy = new HashSet<AssemblyReferenceInfo>();
+
+        #endregion
+
+        #region Properties
+
+        public AssemblyName AssemblyName { get; private set; }
+        public AssemblyReferenceInfo[] ReferencedBy { get { return _ReferencedBy.ToArray(); } }
+        public AssemblyReferenceInfo[] References { get { return _References.ToArray(); } }
+
+        #endregion
+
+        #region Constructor
+
+        public AssemblyReferenceInfo(AssemblyName assemblyName)
+        {
+            AssemblyName = assemblyName;
+        }
+
+        #endregion
+
+        #region Reference Support
+
+        public void AddReference(AssemblyReferenceInfo info)
+        {
+            if (!_References.Contains(info))
+            {
+                _References.Add(info);
+            }
+        }
+
+        public void AddReferencedBy(AssemblyReferenceInfo info)
+        {
+            if (!_ReferencedBy.Contains(info))
+            {
+                _ReferencedBy.Add(info);
+            }
+        }
+
+        #endregion
+
+        #region HashCode Support
+
+        public override int GetHashCode()
+        {
+            return AssemblyName.FullName.GetHashCode();
+        }
+
+        public override bool Equals(object obj)
+        {
+            var info = obj as AssemblyReferenceInfo;
+            if (info == null)
+            {
+                return false;
+            }
+            return info.AssemblyName.FullName == AssemblyName.FullName;
+        }
+
+        #endregion
+    }
+}

--- a/AsmSpy/ConsoleVisualizer.cs
+++ b/AsmSpy/ConsoleVisualizer.cs
@@ -1,0 +1,114 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace AsmSpy
+{
+    public class ConsoleVisualizer : IDependencyVisualizer
+    {
+        static readonly ConsoleColor[] ConsoleColors = new ConsoleColor[]
+        {
+            ConsoleColor.Green,
+            ConsoleColor.Red,
+            ConsoleColor.Yellow,
+            ConsoleColor.Blue,
+            ConsoleColor.Cyan,
+            ConsoleColor.Magenta,
+        };
+
+        #region Fields
+
+        DependencyAnalyzerResult _AnalyzerResult;
+
+        #endregion
+
+        #region Properties
+
+        public bool OnlyConflicts { get; set; }
+        public bool SkipSystem { get; set; }
+
+        #endregion
+
+        #region Constructor
+
+        public ConsoleVisualizer(DependencyAnalyzerResult result)
+        {
+            _AnalyzerResult = result;
+        }
+
+        #endregion
+
+        #region Visualize Support
+
+        public void Visualize()
+        {
+            if (_AnalyzerResult.AnalyzedFiles.Length <= 0)
+            {
+                Console.WriteLine("No dll files found in directory");
+                return;
+            }
+
+            if (OnlyConflicts)
+            {
+                Console.WriteLine("Detailing only conflicting assembly references.");
+            }
+
+            foreach (var assemblyReferences in _AnalyzerResult.Assemblies.OrderBy(i => i.Key))
+            {
+                if (SkipSystem && (assemblyReferences.Key.StartsWith("System") || assemblyReferences.Key.StartsWith("mscorlib"))) continue;
+
+                var referencesTo = assemblyReferences.Value.ReferencedBy;
+
+                if (!OnlyConflicts || referencesTo.Length > 0)
+                {
+                    Console.ForegroundColor = ConsoleColor.White;
+                    Console.Write("Reference: ");
+                    Console.ForegroundColor = ConsoleColor.Gray;
+                    Console.WriteLine("{0}", assemblyReferences.Key);
+
+                    var referencedAssemblies = new List<Tuple<string, string>>();
+                    var versionsList = new List<string>();
+                    var asmList = new List<string>();
+                    foreach (var referencedAssembly in referencesTo)
+                    {
+                        var s1 = referencedAssembly.AssemblyName.Version.ToString();
+                        var s2 = referencedAssembly.AssemblyName.FullName;
+                        var tuple = new Tuple<string, string>(s1, s2);
+                        referencedAssemblies.Add(tuple);
+                    }
+
+                    foreach (var referencedAssembly in referencedAssemblies)
+                    {
+                        if (!versionsList.Contains(referencedAssembly.Item1))
+                        {
+                            versionsList.Add(referencedAssembly.Item1);
+                        }
+                        if (!asmList.Contains(referencedAssembly.Item1))
+                        {
+                            asmList.Add(referencedAssembly.Item1);
+                        }
+                    }
+
+                    foreach (var referencedAssembly in referencedAssemblies)
+                    {
+                        var versionColor = ConsoleColors[versionsList.IndexOf(referencedAssembly.Item1) % ConsoleColors.Length];
+
+                        Console.ForegroundColor = versionColor;
+                        Console.Write("   {0}", referencedAssembly.Item1);
+
+                        Console.ForegroundColor = ConsoleColor.White;
+                        Console.Write(" by ");
+
+                        Console.ForegroundColor = ConsoleColor.Gray;
+                        Console.WriteLine("{0}", referencedAssembly.Item2);
+                    }
+
+                    Console.WriteLine();
+                }
+            }
+        }
+
+        #endregion
+    }
+}

--- a/AsmSpy/DependencyAnalyzer.cs
+++ b/AsmSpy/DependencyAnalyzer.cs
@@ -1,0 +1,84 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Text;
+using AsmSpy.Native;
+
+namespace AsmSpy
+{
+    public class DependencyAnalyzer : IDependencyAnalyzer
+    {
+        #region Properties
+
+        public DirectoryInfo DirectoryInfo { get; set; }
+
+        #endregion
+
+        #region Analyze Support
+
+        private IEnumerable<FileInfo> GetLibrariesAndExecutables()
+        {
+            return DirectoryInfo.GetFiles("*.dll").Concat(DirectoryInfo.GetFiles("*.exe"));
+        }
+
+        private AssemblyReferenceInfo GetAssemblyReferenceInfo(Dictionary<string, AssemblyReferenceInfo> assemblies, AssemblyName assemblyName)
+        {
+            AssemblyReferenceInfo assemblyReferenceInfo;
+            if (!assemblies.TryGetValue(assemblyName.FullName, out assemblyReferenceInfo))
+            {
+                assemblyReferenceInfo = new AssemblyReferenceInfo(assemblyName);
+                assemblies.Add(assemblyName.FullName, assemblyReferenceInfo);
+            }
+            return assemblyReferenceInfo;
+        }
+
+
+        public DependencyAnalyzerResult Analyze(Action<string> assemblyStart)
+        {
+            var result = new DependencyAnalyzerResult();
+
+            result.AnalyzedFiles = GetLibrariesAndExecutables().ToArray();
+
+            if (result.AnalyzedFiles.Length <= 0)
+            {
+                return result;
+            }
+
+            result.Assemblies = new Dictionary<string, AssemblyReferenceInfo>(StringComparer.OrdinalIgnoreCase);
+            foreach (var fileInfo in result.AnalyzedFiles.OrderBy(asm => asm.Name))
+            {
+                assemblyStart?.Invoke(fileInfo.Name);
+                Assembly assembly;
+                try
+                {
+                    if (!fileInfo.IsAssembly())
+                    {
+                        continue;
+                    }
+                    assembly = Assembly.ReflectionOnlyLoadFrom(fileInfo.FullName);
+                }
+                catch (Exception ex)
+                {
+                    Console.WriteLine("Failed to load assembly '{0}': {1}", fileInfo.FullName, ex.Message);
+                    continue;
+                }
+                var assemblyReferenceInfo = GetAssemblyReferenceInfo(result.Assemblies, assembly.GetName());
+
+                foreach (var referencedAssembly in assembly.GetReferencedAssemblies())
+                {
+                    var referencedAssemblyReferenceInfo = GetAssemblyReferenceInfo(result.Assemblies, referencedAssembly); ;
+                    assemblyReferenceInfo.AddReference(referencedAssemblyReferenceInfo);
+                    referencedAssemblyReferenceInfo.AddReferencedBy(assemblyReferenceInfo);
+                }
+            }
+
+            
+            return result;
+        }
+
+        #endregion
+    }
+}
+

--- a/AsmSpy/DependencyAnalyzerReport.cs
+++ b/AsmSpy/DependencyAnalyzerReport.cs
@@ -1,0 +1,14 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+
+namespace AsmSpy
+{
+    public class DependencyAnalyzerResult
+    {
+        public FileInfo[] AnalyzedFiles { get; set; }
+        public Dictionary<string, AssemblyReferenceInfo> Assemblies { get; set; }
+    }
+}

--- a/AsmSpy/IDependencyAnalyzer.cs
+++ b/AsmSpy/IDependencyAnalyzer.cs
@@ -1,0 +1,14 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+
+namespace AsmSpy
+{
+    public interface IDependencyAnalyzer
+    {
+        DependencyAnalyzerResult Analyze(Action<string> assemblyStart);
+        DirectoryInfo DirectoryInfo { get; }
+    }
+}

--- a/AsmSpy/IDependencyVisualizer.cs
+++ b/AsmSpy/IDependencyVisualizer.cs
@@ -1,0 +1,12 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace AsmSpy
+{
+    public interface IDependencyVisualizer
+    {
+        void Visualize();
+    }
+}

--- a/AsmSpy/Program.cs
+++ b/AsmSpy/Program.cs
@@ -9,16 +9,6 @@ namespace AsmSpy
 {
     public class Program
     {
-        static readonly ConsoleColor[] ConsoleColors = new ConsoleColor[]
-        {
-            ConsoleColor.Green,
-            ConsoleColor.Red,
-            ConsoleColor.Yellow,
-            ConsoleColor.Blue,
-            ConsoleColor.Cyan,
-            ConsoleColor.Magenta,
-        };
-
         static readonly string[] HelpSwitches = new string[] { "/?", "-?", "-help", "--help" };
         static readonly string[] NonSystemSwitches = new string[] { "/n", "nonsystem", "/nonsystem" };
         static readonly string[] AllSwitches = new string[] { "/a", "all", "/all" };
@@ -45,106 +35,19 @@ namespace AsmSpy
             var onlyConflicts = !args.Skip(1).Any(x => AllSwitches.Contains(x, StringComparer.OrdinalIgnoreCase));  
             var skipSystem = args.Skip(1).Any(x => NonSystemSwitches.Contains(x, StringComparer.OrdinalIgnoreCase));
 
-            AnalyseAssemblies(new DirectoryInfo(directoryPath), onlyConflicts, skipSystem);
-        }
-
-        public static void AnalyseAssemblies(DirectoryInfo directoryInfo, bool onlyConflicts, bool skipSystem)
-        {
-            var assemblyFiles = directoryInfo.GetFiles("*.dll").Concat(directoryInfo.GetFiles("*.exe"));
-            if (!assemblyFiles.Any())
-            {
-                Console.WriteLine("No dll files found in directory: '{0}'",
-                    directoryInfo.FullName);
-                return;
-            }
+            IDependencyAnalyzer analyzer = new DependencyAnalyzer() { DirectoryInfo = new DirectoryInfo(directoryPath) };
 
             Console.WriteLine("Check assemblies in:");
-            Console.WriteLine(directoryInfo.FullName);
+            Console.WriteLine(analyzer.DirectoryInfo);
             Console.WriteLine("");
 
-            var assemblies = new Dictionary<string, IList<ReferencedAssembly>>(StringComparer.OrdinalIgnoreCase);
-            foreach (var fileInfo in assemblyFiles.OrderBy(asm => asm.Name))
-            {
-                Assembly assembly = null;
-                try
-                {
-                    if (!fileInfo.IsAssembly())
-                    {
-                        continue;
-                    }
-                    assembly = Assembly.ReflectionOnlyLoadFrom(fileInfo.FullName);
-                }
-                catch (Exception ex)
-                {
-                    Console.WriteLine("Failed to load assembly '{0}': {1}", fileInfo.FullName, ex.Message);
-                    continue;
-                }
+            var result = analyzer.Analyze(assemblyName => Console.WriteLine(string.Format("Checking {0}", assemblyName)));
 
-                foreach (var referencedAssembly in assembly.GetReferencedAssemblies())
-                {
-                    if (!assemblies.ContainsKey(referencedAssembly.Name))
-                    {
-                        assemblies.Add(referencedAssembly.Name, new List<ReferencedAssembly>());
-                    }
-                    assemblies[referencedAssembly.Name]
-                        .Add(new ReferencedAssembly(referencedAssembly.Version, assembly));
-                }
-            }
+            IDependencyVisualizer visualizer = new ConsoleVisualizer(result) { SkipSystem = skipSystem, OnlyConflicts = onlyConflicts };
+            visualizer.Visualize();
 
-            if (onlyConflicts)
-                Console.WriteLine("Detailing only conflicting assembly references.");
+            Console.ReadLine();
 
-            foreach (var assemblyReferences in assemblies.OrderBy(i => i.Key))
-            {
-                if (skipSystem && (assemblyReferences.Key.StartsWith("System") || assemblyReferences.Key.StartsWith("mscorlib"))) continue;
-
-                if (!onlyConflicts || assemblyReferences.Value.GroupBy(x => x.VersionReferenced).Count() != 1)
-                {
-                    Console.ForegroundColor = ConsoleColor.White;
-                    Console.Write("Reference: ");
-                    Console.ForegroundColor = ConsoleColor.Gray;
-                    Console.WriteLine("{0}", assemblyReferences.Key);
-
-                    var referencedAssemblies = new List<Tuple<string, string>>();
-                    var versionsList = new List<string>();
-                    var asmList = new List<string>();
-                    foreach (var referencedAssembly in assemblyReferences.Value)
-                    {
-                        var s1 = referencedAssembly.VersionReferenced.ToString();
-                        var s2 = referencedAssembly.ReferencedBy.GetName().Name;
-                        var tuple = new Tuple<string, string>(s1, s2);
-                        referencedAssemblies.Add(tuple);
-                    }
-
-                    foreach (var referencedAssembly in referencedAssemblies)
-                    {
-                        if (!versionsList.Contains(referencedAssembly.Item1))
-                        {
-                            versionsList.Add(referencedAssembly.Item1);
-                        }
-                        if (!asmList.Contains(referencedAssembly.Item1))
-                        {
-                            asmList.Add(referencedAssembly.Item1);
-                        }
-                    }
-
-                    foreach (var referencedAssembly in referencedAssemblies)
-                    {
-                        var versionColor = ConsoleColors[versionsList.IndexOf(referencedAssembly.Item1) % ConsoleColors.Length];
-
-                        Console.ForegroundColor = versionColor;
-                        Console.Write("   {0}", referencedAssembly.Item1);
-
-                        Console.ForegroundColor = ConsoleColor.White;
-                        Console.Write(" by ");
-
-                        Console.ForegroundColor = ConsoleColor.Gray;
-                        Console.WriteLine("{0}", referencedAssembly.Item2);
-                    }
-
-                    Console.WriteLine();
-                }
-            }
         }
 
         private static void PrintDirectoryNotFound(string directoryPath)
@@ -167,18 +70,6 @@ namespace AsmSpy
             Console.WriteLine(@"AsmSpy C:\Source\My.Solution\My.Project\bin\Debug");
             Console.WriteLine(@"AsmSpy C:\Source\My.Solution\My.Project\bin\Debug all");
             Console.WriteLine(@"AsmSpy C:\Source\My.Solution\My.Project\bin\Debug nonsystem");
-        }
-    }
-
-    public class ReferencedAssembly
-    {
-        public Version VersionReferenced { get; private set; }
-        public Assembly ReferencedBy { get; private set; }
-
-        public ReferencedAssembly(Version versionReferenced, Assembly referencedBy)
-        {
-            VersionReferenced = versionReferenced;
-            ReferencedBy = referencedBy;
         }
     }
 }


### PR DESCRIPTION
Seperated visualization from analyzing by using a Analyzer and Visualizer class.

I have moved the analyzer code to a class that only searches the references and moved the visualization logic to a visualizer class. There is no change in logic or output. This separation makes sure the "S" of "SOLID" is applied and that in the future other visualizers can be build. One I can already imagine (I'm using it now for a project with 300 assemblies) is the DGML output that can be used in visual studio. https://msdn.microsoft.com/en-us/library/ee842619.aspx explains the use in visual studio.  
When this change is accepted I will add support to output DGML