### PR TITLE
Fixed reference version numbers, merged references to groups by name, with different assemblies as sub-groups

### DIFF
--- a/AsmSpy/AsmSpy.csproj
+++ b/AsmSpy/AsmSpy.csproj
@@ -36,6 +36,7 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <Prefer32Bit>false</Prefer32Bit>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Microsoft.Extensions.CommandLineUtils, Version=1.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
@@ -48,6 +49,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="AssemblyReferenceInfo.cs" />
+    <Compile Include="AssemblySource.cs" />
     <Compile Include="ConsoleLogger.cs" />
     <Compile Include="ConsoleVisualizer.cs" />
     <Compile Include="DependencyAnalyzer.cs" />

--- a/AsmSpy/AssemblyReferenceInfo.cs
+++ b/AsmSpy/AssemblyReferenceInfo.cs
@@ -17,6 +17,8 @@ namespace AsmSpy
 
         #region Properties
 
+        public Assembly ReflectionOnlyAssembly { get; set; }
+        public AssemblySource AssemblySource { get; set; }
         public AssemblyName AssemblyName { get; private set; }
         public AssemblyReferenceInfo[] ReferencedBy { get { return _ReferencedBy.ToArray(); } }
         public AssemblyReferenceInfo[] References { get { return _References.ToArray(); } }

--- a/AsmSpy/AssemblySource.cs
+++ b/AsmSpy/AssemblySource.cs
@@ -1,0 +1,10 @@
+﻿namespace AsmSpy
+{
+    public enum AssemblySource
+    {
+        NotFound,
+        Local,
+        GAC,
+        Unknown
+    }
+}

--- a/AsmSpy/ConsoleVisualizer.cs
+++ b/AsmSpy/ConsoleVisualizer.cs
@@ -61,40 +61,37 @@ namespace AsmSpy
 
                 if (SkipSystem && (assemblyGroup.Key.StartsWith("System") || assemblyGroup.Key.StartsWith("mscorlib"))) continue;
 
-                var totalReferenceCount = assemblyGroup.Sum(x => x.ReferencedBy.Length);
+                //var assemblyInfos = assemblyGroup.OrderBy(x => x.AssemblyName.Version).ToList();
+                var assemblyInfos = assemblyGroup.OrderByDescending(x => x.ReferencedBy.Length).ToList();
+                if (OnlyConflicts && assemblyInfos.Count <= 1) continue;
 
-                if (!OnlyConflicts || totalReferenceCount > 0)
+                Console.ForegroundColor = ConsoleColor.White;
+                Console.Write("Reference: ");
+                Console.ForegroundColor = ConsoleColor.Gray;
+                Console.WriteLine("{0}", assemblyGroup.Key);
+                
+                for (var i = 0; i < assemblyInfos.Count; i++)
                 {
-                    Console.ForegroundColor = ConsoleColor.White;
-                    Console.Write("Reference: ");
-                    Console.ForegroundColor = ConsoleColor.Gray;
-                    Console.WriteLine("{0}", assemblyGroup.Key);
+                    var assemblyInfo = assemblyInfos[i];
+                    var versionColor = ConsoleColors[i % ConsoleColors.Length];
 
-                    //var assemblyInfos = assemblyGroup.OrderBy(x => x.AssemblyName.Version).ToList();
-                    var assemblyInfos = assemblyGroup.OrderByDescending(x => x.ReferencedBy.Length).ToList();
-                    for (var i = 0; i < assemblyInfos.Count; i++)
+                    Console.ForegroundColor = versionColor;
+                    Console.WriteLine("  {0}", assemblyInfo.AssemblyName);
+
+                    foreach (var referer in assemblyInfo.ReferencedBy)
                     {
-                        var assemblyInfo = assemblyInfos[i];
-                        var versionColor = ConsoleColors[i % ConsoleColors.Length];
-
                         Console.ForegroundColor = versionColor;
-                        Console.WriteLine("  {0}", assemblyInfo.AssemblyName);
+                        Console.Write("    {0}", assemblyInfo.AssemblyName.Version);
 
-                        foreach (var referer in assemblyInfo.ReferencedBy)
-                        {
-                            Console.ForegroundColor = versionColor;
-                            Console.Write("    {0}", assemblyInfo.AssemblyName.Version);
+                        Console.ForegroundColor = ConsoleColor.White;
+                        Console.Write(" by ");
 
-                            Console.ForegroundColor = ConsoleColor.White;
-                            Console.Write(" by ");
-
-                            Console.ForegroundColor = ConsoleColor.Gray;
-                            Console.WriteLine("{0}", referer.AssemblyName);
-                        }
+                        Console.ForegroundColor = ConsoleColor.Gray;
+                        Console.WriteLine("{0}", referer.AssemblyName);
                     }
-
-                    Console.WriteLine();
                 }
+
+                Console.WriteLine();
             }
         }
 

--- a/AsmSpy/ConsoleVisualizer.cs
+++ b/AsmSpy/ConsoleVisualizer.cs
@@ -45,7 +45,7 @@ namespace AsmSpy
         {
             if (_AnalyzerResult.AnalyzedFiles.Length <= 0)
             {
-                Console.WriteLine("No dll files found in directory");
+                Console.WriteLine("No assemblies files found in directory");
                 return;
             }
 
@@ -76,7 +76,7 @@ namespace AsmSpy
                     var versionColor = ConsoleColors[i % ConsoleColors.Length];
 
                     Console.ForegroundColor = versionColor;
-                    Console.WriteLine("  {0}", assemblyInfo.AssemblyName);
+                    Console.WriteLine("  {0}, Source: {1}", assemblyInfo.AssemblyName, assemblyInfo.AssemblySource);
 
                     foreach (var referer in assemblyInfo.ReferencedBy)
                     {

--- a/AsmSpy/ConsoleVisualizer.cs
+++ b/AsmSpy/ConsoleVisualizer.cs
@@ -54,54 +54,43 @@ namespace AsmSpy
                 Console.WriteLine("Detailing only conflicting assembly references.");
             }
 
-            foreach (var assemblyReferences in _AnalyzerResult.Assemblies.OrderBy(i => i.Key))
+            var assemblyGroups = _AnalyzerResult.Assemblies.Values.GroupBy(x => x.AssemblyName.Name);
+
+            foreach (var assemblyGroup in assemblyGroups.OrderBy(i => i.Key))
             {
-                if (SkipSystem && (assemblyReferences.Key.StartsWith("System") || assemblyReferences.Key.StartsWith("mscorlib"))) continue;
 
-                var referencesTo = assemblyReferences.Value.ReferencedBy;
+                if (SkipSystem && (assemblyGroup.Key.StartsWith("System") || assemblyGroup.Key.StartsWith("mscorlib"))) continue;
 
-                if (!OnlyConflicts || referencesTo.Length > 0)
+                var totalReferenceCount = assemblyGroup.Sum(x => x.ReferencedBy.Length);
+
+                if (!OnlyConflicts || totalReferenceCount > 0)
                 {
                     Console.ForegroundColor = ConsoleColor.White;
                     Console.Write("Reference: ");
                     Console.ForegroundColor = ConsoleColor.Gray;
-                    Console.WriteLine("{0}", assemblyReferences.Key);
+                    Console.WriteLine("{0}", assemblyGroup.Key);
 
-                    var referencedAssemblies = new List<Tuple<string, string>>();
-                    var versionsList = new List<string>();
-                    var asmList = new List<string>();
-                    foreach (var referencedAssembly in referencesTo)
+                    //var assemblyInfos = assemblyGroup.OrderBy(x => x.AssemblyName.Version).ToList();
+                    var assemblyInfos = assemblyGroup.OrderByDescending(x => x.ReferencedBy.Length).ToList();
+                    for (var i = 0; i < assemblyInfos.Count; i++)
                     {
-                        var s1 = referencedAssembly.AssemblyName.Version.ToString();
-                        var s2 = referencedAssembly.AssemblyName.FullName;
-                        var tuple = new Tuple<string, string>(s1, s2);
-                        referencedAssemblies.Add(tuple);
-                    }
-
-                    foreach (var referencedAssembly in referencedAssemblies)
-                    {
-                        if (!versionsList.Contains(referencedAssembly.Item1))
-                        {
-                            versionsList.Add(referencedAssembly.Item1);
-                        }
-                        if (!asmList.Contains(referencedAssembly.Item1))
-                        {
-                            asmList.Add(referencedAssembly.Item1);
-                        }
-                    }
-
-                    foreach (var referencedAssembly in referencedAssemblies)
-                    {
-                        var versionColor = ConsoleColors[versionsList.IndexOf(referencedAssembly.Item1) % ConsoleColors.Length];
+                        var assemblyInfo = assemblyInfos[i];
+                        var versionColor = ConsoleColors[i % ConsoleColors.Length];
 
                         Console.ForegroundColor = versionColor;
-                        Console.Write("   {0}", referencedAssembly.Item1);
+                        Console.WriteLine("  {0}", assemblyInfo.AssemblyName);
 
-                        Console.ForegroundColor = ConsoleColor.White;
-                        Console.Write(" by ");
+                        foreach (var referer in assemblyInfo.ReferencedBy)
+                        {
+                            Console.ForegroundColor = versionColor;
+                            Console.Write("    {0}", assemblyInfo.AssemblyName.Version);
 
-                        Console.ForegroundColor = ConsoleColor.Gray;
-                        Console.WriteLine("{0}", referencedAssembly.Item2);
+                            Console.ForegroundColor = ConsoleColor.White;
+                            Console.Write(" by ");
+
+                            Console.ForegroundColor = ConsoleColor.Gray;
+                            Console.WriteLine("{0}", referer.AssemblyName);
+                        }
                     }
 
                     Console.WriteLine();


### PR DESCRIPTION
For issue #29 
Fixed reference version numbers, merged references to groups by name, with different assemblies as sub-groups. The colors also make sense now.

Preview:
![image](https://cloud.githubusercontent.com/assets/7861188/19560356/d99dc314-96dc-11e6-91c7-07ab7107fa59.png)
