### PR TITLE
Show help when run with no arguments

### DIFF
--- a/AsmSpy/Program.cs
+++ b/AsmSpy/Program.cs
@@ -53,7 +53,10 @@ namespace AsmSpy
             });
             try
             {
-                commandLineApplication.Execute(args);
+                if (args == null || args.Length == 0)
+                    commandLineApplication.ShowHelp();
+                else
+                    commandLineApplication.Execute(args);
             }
             catch (CommandParsingException cpe)
             {


### PR DESCRIPTION
When asmspy is run without any arguments it should show help.  At present it displays the message '_Directory: '' does not exist._'. 