### PR TITLE
Changed colors to mean reference availability, added reference locations to the console output

### DIFF
--- a/AsmSpy/ConsoleVisualizer.cs
+++ b/AsmSpy/ConsoleVisualizer.cs
@@ -55,8 +55,7 @@ namespace AsmSpy
             {
                 if (SkipSystem && (assemblyGroup.Key.StartsWith("System") || assemblyGroup.Key.StartsWith("mscorlib"))) continue;
 
-                //var assemblyInfos = assemblyGroup.OrderBy(x => x.AssemblyName.Version).ToList();
-                var assemblyInfos = assemblyGroup.OrderByDescending(x => x.ReferencedBy.Length).ToList();
+                var assemblyInfos = assemblyGroup.OrderBy(x => x.AssemblyName.ToString()).ToList();
                 if (OnlyConflicts && assemblyInfos.Count <= 1) continue;
 
                 Console.ForegroundColor = ConsoleColor.White;
@@ -117,7 +116,7 @@ namespace AsmSpy
                         Console.WriteLine();
                     }
 
-                    foreach (var referer in assemblyInfo.ReferencedBy)
+                    foreach (var referer in assemblyInfo.ReferencedBy.OrderBy(x => x.AssemblyName.ToString()))
                     {
                         Console.ForegroundColor = statusColor;
                         Console.Write("    {0}", assemblyInfo.AssemblyName.Version);

--- a/README.md
+++ b/README.md
@@ -62,6 +62,6 @@ You can see that System.Web.Mvc is referenced by 7 assemblies in my bin folder. 
 version 2.0.0.0 and some version 3.0.0.0. I can now resolve any conflicts.
 
 Color coding is used to more easily distinguish any problems.
-* Green - refered assembly found locally, in the specified directory
-* Yellow - refered assembly not found locally, but found installed in the [Global Assembly Cache](https://msdn.microsoft.com/en-us/library/yf1d93sz(v=vs.110).aspx)
-* Red - refered assembly missing
+* Green - referenced assembly found locally, in the specified directory
+* Yellow - referenced assembly not found locally, but found installed in the [Global Assembly Cache](https://msdn.microsoft.com/en-us/library/yf1d93sz(v=vs.110).aspx)
+* Red - referenced assembly missing

--- a/README.md
+++ b/README.md
@@ -24,13 +24,16 @@ It will output a list of all conflicting assembly references. That is where diff
 ### Switches:
 | Switch | Description |
 | --- | --- |
-| all | list all assemblies and references.<br> Supported formats:  /a, all, /all |
-| nonsystem | list system assemblies. <br> Supported formats:  /n, nonsystem, /nonsystem |
+| all | list all assemblies and references.<br> Supported formats:  -a, --all |
+| nonsystem | list system assemblies. <br> Supported formats:  -n, --nonsystem |
+| noconsole | do not show reference output on console.<br> Supported formats:  -nc, --noconsole |
+| silent | do not show any output, only warnings and errors will be shown.<br> Supported formats:  -s, --silent |
+| dgml | export dependancy graph to a dgml file.<br> Supported formats:  -dg \<filename\>, --silent \<filename\> |
 
 ### Examples
 To see a list of all assemblies and all references, just add the 'all' flag:
 
-    AsmSpy D:\Source\sutekishop\Suteki.Shop\Suteki.Shop\bin all
+    AsmSpy D:\Source\sutekishop\Suteki.Shop\Suteki.Shop\bin --all
     
 To ignore system assemblies, add the 'nonsystem' flag.
 
@@ -58,3 +61,7 @@ The output looks something like this:
 You can see that System.Web.Mvc is referenced by 7 assemblies in my bin folder. Some reference 
 version 2.0.0.0 and some version 3.0.0.0. I can now resolve any conflicts.
 
+Color coding is used to more easily distinguish any problems.
+* Green - refered assembly found locally, in the specified directory
+* Yellow - refered assembly not found locally, but found installed in the [Global Assembly Cache](https://msdn.microsoft.com/en-us/library/yf1d93sz(v=vs.110).aspx)
+* Red - refered assembly missing


### PR DESCRIPTION
I made the console visualizer show specific locations for all assemblies (if found). I may need to add a command-line argument to enable it though, since while useful it does look a bit cluttered now.

The colors before used to be arbitrary, meaning first dependancy version is green, second is red, third is yellow, etc. Since it wasn't properly explained and people usually associate colors with specific meanings, it was counter-intuitive.

I changed colors to have specific meanings, and added them to `README.md`:
* Green - referenced assembly found locally, in the specified directory
* Yellow - referenced assembly not found locally, but found installed in the [Global Assembly Cache](https://msdn.microsoft.com/en-us/library/yf1d93sz(v=vs.110).aspx)
* Red - referenced assembly missing

This should also solve #28

Preview:
![image](https://cloud.githubusercontent.com/assets/7861188/19590632/90b96758-977b-11e6-9086-0977720dca4a.png)

Note that it still doesn't pay attention to [Binding redirects](https://msdn.microsoft.com/en-us/library/7wd6ex19(v=vs.110).aspx), which may sometimes lead it to show wrong statuses. I'll try to fix this once I have some more time on my hands.