### PR TITLE
Allows user to enter bin folder path in the console application

### DIFF
--- a/AsmSpy.CommandLine/AsmSpy.CommandLine.csproj
+++ b/AsmSpy.CommandLine/AsmSpy.CommandLine.csproj
@@ -40,9 +40,8 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Microsoft.Extensions.CommandLineUtils, Version=1.1.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.Extensions.CommandLineUtils.1.1.0\lib\net451\Microsoft.Extensions.CommandLineUtils.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Microsoft.Extensions.CommandLineUtils">
+      <HintPath>..\..\..\Users\george\Documents\Visual Studio 2017\Projects\Miyabi DMS\TestingLibrary\AsmSpy\packages\Microsoft.Extensions.CommandLineUtils.1.1.0\lib\net451\Microsoft.Extensions.CommandLineUtils.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />

--- a/AsmSpy.CommandLine/Program.cs
+++ b/AsmSpy.CommandLine/Program.cs
@@ -63,9 +63,15 @@ namespace AsmSpy.CommandLine
             });
             try
             {
-                if (args == null || args.Length == 0)
+                if (args.Length < 1)
                 {
                     commandLineApplication.ShowHelp();
+
+                    Console.WriteLine("Enter path to your project bin folder containing dependencies to check.");
+                    string input = Console.ReadLine();
+
+                    args = new string[] { input };
+                    commandLineApplication.Execute(args);
                 }
                 else
                 {
@@ -77,6 +83,9 @@ namespace AsmSpy.CommandLine
                 Console.WriteLine(cpe.Message);
                 commandLineApplication.ShowHelp();
             }
+
+            Console.ReadKey();
         }
+
     }
 }


### PR DESCRIPTION
I cloned the project from github and run it directly using visual studio. The console window would fire up and die instantly. I wanted to optionally add my bin folder path in the console and still get the app to run. Someone else might see the app crash and think that the app is faulty which is not true. 

The application is quite helpful btw, Thanks @hickford and @michaelthyregod  for the good work!!

Thank you!