### PR TITLE
DgmlExport should respect the --nonsystem flag

### DIFF
--- a/AsmSpy.CommandLine/ConsoleVisualizer.cs
+++ b/AsmSpy.CommandLine/ConsoleVisualizer.cs
@@ -22,6 +22,7 @@ namespace AsmSpy.CommandLine
         #region Properties
 
         public bool OnlyConflicts { get; set; }
+
         public bool SkipSystem { get; set; }
 
         public string ReferencedStartsWith { get; set; }
@@ -52,16 +53,16 @@ namespace AsmSpy.CommandLine
                 Console.WriteLine(AsmSpy_CommandLine.Detailing_only_conflicting_assembly_references);
             }
 
-            var assemblyGroups = _analyzerResult.Assemblies.Values.GroupBy(x => x.AssemblyName.Name);
+            var assemblyGroups = _analyzerResult.Assemblies.Values.GroupBy(x => x.AssemblyName);
 
-            foreach (var assemblyGroup in assemblyGroups.OrderBy(i => i.Key))
+            foreach (var assemblyGroup in assemblyGroups.OrderBy(i => i.Key.Name))
             {
-                if (SkipSystem && (assemblyGroup.Key.ToUpperInvariant().StartsWith("SYSTEM", StringComparison.OrdinalIgnoreCase) || assemblyGroup.Key.ToUpperInvariant().StartsWith("MSCORLIB", StringComparison.OrdinalIgnoreCase)))
+                if (SkipSystem && AssemblyInformationProvider.IsSystemAssembly(assemblyGroup.Key))
                 {
                     continue;
                 }
 
-                var assemblyInfos = assemblyGroup.OrderBy(x => x.AssemblyName.ToString()).ToList();
+                var assemblyInfos = assemblyGroup.OrderBy(x => x.AssemblyName.Name).ToList();
                 if (OnlyConflicts && assemblyInfos.Count <= 1)
                 {
                     if (assemblyInfos.Count == 1 && assemblyInfos[0].AssemblySource == AssemblySource.Local)

--- a/AsmSpy.CommandLine/DgmlExport.cs
+++ b/AsmSpy.CommandLine/DgmlExport.cs
@@ -1,4 +1,5 @@
-﻿using System.Globalization;
+﻿using System.Collections.Generic;
+using System.Globalization;
 using System.IO;
 using System.Text;
 using AsmSpy.Core;
@@ -18,12 +19,20 @@ namespace AsmSpy.CommandLine
             _logger = logger;
         }
 
+        #region Properties
+
+        public bool SkipSystem { get; set; }
+
+        #endregion
+
         public void Visualize()
         {
             var nodes = new StringBuilder();
-
             foreach (var assemblyReference in _result.Assemblies.Values)
             {
+                if (SkipSystem && assemblyReference.IsSystem)
+                    continue;
+
                 nodes.AppendFormat(CultureInfo.InvariantCulture, "<Node Id=\"{0}\" Label=\"{1}\" Category=\"Assembly\" />\n",
                     assemblyReference.AssemblyName.FullName, assemblyReference.AssemblyName.Name);
             }
@@ -31,8 +40,14 @@ namespace AsmSpy.CommandLine
             var links = new StringBuilder();
             foreach (var assemblyReference in _result.Assemblies.Values)
             {
+                if (SkipSystem && assemblyReference.IsSystem)
+                    continue;
+
                 foreach (var referenceTo in assemblyReference.References)
                 {
+                    if (SkipSystem && referenceTo.IsSystem)
+                        continue;
+
                     links.AppendFormat(CultureInfo.InvariantCulture, "<Link Source=\"{0}\" Target=\"{1}\" Category=\"Reference\" />\n",
                         assemblyReference.AssemblyName.FullName, referenceTo.AssemblyName.FullName);
                 }

--- a/AsmSpy.CommandLine/Program.cs
+++ b/AsmSpy.CommandLine/Program.cs
@@ -76,13 +76,13 @@ namespace AsmSpy.CommandLine
 
                 if (dgmlExport.HasValue())
                 {
-
-                    IDependencyVisualizer export = new DgmlExport(result, string.IsNullOrWhiteSpace(dgmlExport.Value()) ? Path.Combine(directoryInfo.FullName, "references.dgml") : dgmlExport.Value(), consoleLogger);
+                    IDependencyVisualizer export = new DgmlExport(result, string.IsNullOrWhiteSpace(dgmlExport.Value()) ? Path.Combine(directoryInfo.FullName, "references.dgml") : dgmlExport.Value(), consoleLogger) { SkipSystem = skipSystem };
                     export.Visualize();
                 }
 
                 if (bindingRedirect.HasValue())
                 {
+                    // binding redirect export explicitly doesn't respect SkipSystem
                     IDependencyVisualizer bindingRedirects = new BindingRedirectExport(result, string.IsNullOrWhiteSpace(dgmlExport.Value()) ? Path.Combine(directoryInfo.FullName, "bindingRedirects.xml") : dgmlExport.Value(), consoleLogger);
                     bindingRedirects.Visualize();
                 }

--- a/AsmSpy.Core/AsmSpy.Core.csproj
+++ b/AsmSpy.Core/AsmSpy.Core.csproj
@@ -76,6 +76,7 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="AssemblyInformationProvider.cs" />
     <Compile Include="AssemblyReferenceInfo.cs" />
     <Compile Include="AssemblySource.cs" />
     <Compile Include="DependencyAnalyzer.cs" />

--- a/AsmSpy.Core/AssemblyInformationProvider.cs
+++ b/AsmSpy.Core/AssemblyInformationProvider.cs
@@ -1,0 +1,37 @@
+﻿using System;
+using System.Collections;
+using System.Reflection;
+
+namespace AsmSpy.Core
+{
+    public static class AssemblyInformationProvider
+    {
+        private static readonly byte[] SystemPublicKeyToken = new byte[] { 183, 122, 92, 86, 25, 52, 224, 137 };
+
+        // some system assemblies are signed with this public key token, but some Microsoft non-system assemblies are signed with it too
+        ////private static readonly byte[] MicrosoftPublicKeyToken = new byte[] { 49, 191, 56, 86, 173, 54, 78, 53 };
+
+        /// <summary>
+        /// Check whether the given assembly name is a system assembly or not.
+        /// </summary>
+        /// <remarks>
+        /// This ISN'T a security check, and shouldn't be used for security decisions.
+        /// Rather this relies on a heuristic and may be used to filter our system assemblies from the dependency graph.
+        /// </remarks>
+        /// <param name="assemblyName">The assembly name to check.</param>
+        /// <returns>true if the assembly name (probably) is a system assembly; otherwise, false.</returns>
+        public static bool IsSystemAssembly(AssemblyName assemblyName)
+        {
+            assemblyName = assemblyName ?? throw new ArgumentNullException(nameof(assemblyName));
+
+            // fairly reliable and easy to check
+            if (StructuralComparisons.StructuralEqualityComparer.Equals(assemblyName.GetPublicKeyToken(), SystemPublicKeyToken))
+            {
+                return true;
+            }
+
+            return assemblyName.Name.StartsWith("System", StringComparison.OrdinalIgnoreCase) ||
+                assemblyName.Name.StartsWith("mscorlib", StringComparison.OrdinalIgnoreCase);
+        }
+    }
+}

--- a/AsmSpy.Core/AssemblyReferenceInfo.cs
+++ b/AsmSpy.Core/AssemblyReferenceInfo.cs
@@ -20,6 +20,7 @@ namespace AsmSpy.Core
         public virtual AssemblyName AssemblyName { get; }
         public virtual ICollection<IAssemblyReferenceInfo> ReferencedBy => _referencedBy.ToArray();
         public virtual ICollection<IAssemblyReferenceInfo> References => _references.ToArray();
+        public bool IsSystem => AssemblyInformationProvider.IsSystemAssembly(AssemblyName);
 
         #endregion
 
@@ -61,12 +62,12 @@ namespace AsmSpy.Core
 
         public override bool Equals(object obj)
         {
-            var info = obj as IAssemblyReferenceInfo;
-            if (info == null)
+            if (obj is IAssemblyReferenceInfo info)
             {
-                return false;
+                return info.AssemblyName.FullName == AssemblyName.FullName;
             }
-            return info.AssemblyName.FullName == AssemblyName.FullName;
+
+            return false;
         }
 
         #endregion

--- a/AsmSpy.Core/IAssemblyReferenceInfo.cs
+++ b/AsmSpy.Core/IAssemblyReferenceInfo.cs
@@ -10,6 +10,7 @@ namespace AsmSpy.Core
         AssemblyName AssemblyName { get; }
         ICollection<IAssemblyReferenceInfo> ReferencedBy { get; }
         ICollection<IAssemblyReferenceInfo> References { get; }
+        bool IsSystem { get; }
         void AddReference(IAssemblyReferenceInfo info);
         void AddReferencedBy(IAssemblyReferenceInfo info);
     }

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,4 +1,5 @@
 version: 1.3.{build}
+image: Visual Studio 2017
 before_build:
   - nuget restore
 # enable patching of AssemblyInfo.* files


### PR DESCRIPTION
Currently only the ConsoleVisualizer respects the --nonsystem flag.
Add support for for the flag to DgmlExport too.