### PR TITLE
feat(binding-redirect): add option to allow binding redirects via provided configuration file (#54)

### DIFF
--- a/AsmSpy.CommandLine/ConsoleVisualizer.cs
+++ b/AsmSpy.CommandLine/ConsoleVisualizer.cs
@@ -1,8 +1,9 @@
-﻿using System;
+﻿using AsmSpy.Core;
+
+using System;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Linq;
-using AsmSpy.Core;
 
 namespace AsmSpy.CommandLine
 {
@@ -10,6 +11,7 @@ namespace AsmSpy.CommandLine
     {
         private const ConsoleColor AssemblyNotFoundColor = ConsoleColor.Red;
         private const ConsoleColor AssemblyLocalColor = ConsoleColor.Green;
+        private const ConsoleColor AssemblyLocalRedirectedColor = ConsoleColor.DarkGreen;
         private const ConsoleColor AssemblyGlobalAssemblyCacheColor = ConsoleColor.Yellow;
         private const ConsoleColor AssemblyUnknownColor = ConsoleColor.Magenta;
 
@@ -53,7 +55,7 @@ namespace AsmSpy.CommandLine
                 Console.WriteLine(AsmSpy_CommandLine.Detailing_only_conflicting_assembly_references);
             }
 
-            var assemblyGroups = _analyzerResult.Assemblies.Values.GroupBy(x => x.AssemblyName);
+            var assemblyGroups = _analyzerResult.Assemblies.Values.GroupBy(x => x.RedirectedAssemblyName);
 
             foreach (var assemblyGroup in assemblyGroups.OrderBy(i => i.Key.Name))
             {
@@ -118,7 +120,14 @@ namespace AsmSpy.CommandLine
             }
             else
             {
-                mainNameColor = AssemblyLocalColor;
+                if (assemblyReferenceInfoList.All(x => x.AssemblyName.FullName == x.RedirectedAssemblyName.FullName))
+                {
+                    mainNameColor = AssemblyLocalColor;
+                }
+                else
+                {
+                    mainNameColor = AssemblyLocalRedirectedColor;
+                }
             }
             return mainNameColor;
         }

--- a/AsmSpy.CommandLine/Program.cs
+++ b/AsmSpy.CommandLine/Program.cs
@@ -12,7 +12,7 @@ namespace AsmSpy.CommandLine
 {
     public static class Program
     {
-        public static void Main(string[] args)
+        public static int Main(string[] args)
         {
             var commandLineApplication = new CommandLineApplication(throwOnUnexpectedArg: true);
             var directoryOrFile = commandLineApplication.Argument("directoryOrFile", "The directory to search for assemblies or file path to a single assembly");
@@ -25,6 +25,7 @@ namespace AsmSpy.CommandLine
             var referencedStartsWith = commandLineApplication.Option("-rsw|--referencedstartswith", "Referenced Assembly should start with <string>. Will only analyze assemblies if their referenced assemblies starts with the given value.", CommandOptionType.SingleValue);
             var includeSubDirectories = commandLineApplication.Option("-i|--includesub", "Include subdirectories in search", CommandOptionType.NoValue);
             var configurationFile = commandLineApplication.Option("-c|--configurationFile", "Use the binding redirects of the given configuration file (Web.config or App.config)", CommandOptionType.SingleValue);
+            var failOnMissing = commandLineApplication.Option("-f|--failOnMissing", "Whether to exit with an error code when AsmSpy detected Assemblies which could not be found", CommandOptionType.NoValue);
 
             commandLineApplication.HelpOption("-? | -h | --help");
             commandLineApplication.OnExecute(() =>
@@ -112,6 +113,10 @@ namespace AsmSpy.CommandLine
                     bindingRedirects.Visualize();
                 }
 
+                if (failOnMissing.HasValue() && result.HasMissingAssemblies)
+                {
+                    return -1;
+                }
                 return 0;
             });
             try
@@ -119,16 +124,16 @@ namespace AsmSpy.CommandLine
                 if (args == null || args.Length == 0)
                 {
                     commandLineApplication.ShowHelp();
+                    return 0;
                 }
-                else
-                {
-                    commandLineApplication.Execute(args);
-                }
+
+                return commandLineApplication.Execute(args);
             }
             catch (CommandParsingException cpe)
             {
                 Console.WriteLine(cpe.Message);
                 commandLineApplication.ShowHelp();
+                return 0;
             }
         }
     }

--- a/AsmSpy.CommandLine/packages.config
+++ b/AsmSpy.CommandLine/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="ILMerge" version="2.14.1208" targetFramework="net462" />
-  <package id="Microsoft.Extensions.CommandLineUtils" version="1.1.0" targetFramework="net452" />
+  <package id="Microsoft.Extensions.CommandLineUtils" version="1.1.0" targetFramework="net462" />
 </packages>

--- a/AsmSpy.Core/AssemblyReferenceInfo.cs
+++ b/AsmSpy.Core/AssemblyReferenceInfo.cs
@@ -6,6 +6,7 @@ namespace AsmSpy.Core
 {
     public class AssemblyReferenceInfo : IAssemblyReferenceInfo
     {
+
         #region Fields
 
         private readonly HashSet<IAssemblyReferenceInfo> _references = new HashSet<IAssemblyReferenceInfo>();
@@ -18,6 +19,7 @@ namespace AsmSpy.Core
         public virtual Assembly ReflectionOnlyAssembly { get; set; }
         public virtual AssemblySource AssemblySource { get; set; }
         public virtual AssemblyName AssemblyName { get; }
+        public virtual AssemblyName RedirectedAssemblyName { get; }
         public virtual ICollection<IAssemblyReferenceInfo> ReferencedBy => _referencedBy.ToArray();
         public virtual ICollection<IAssemblyReferenceInfo> References => _references.ToArray();
         public bool IsSystem => AssemblyInformationProvider.IsSystemAssembly(AssemblyName);
@@ -26,9 +28,10 @@ namespace AsmSpy.Core
 
         #region Constructor
 
-        public AssemblyReferenceInfo(AssemblyName assemblyName)
+        public AssemblyReferenceInfo(AssemblyName assemblyName, AssemblyName redirectedAssemblyName)
         {
             AssemblyName = assemblyName;
+            RedirectedAssemblyName = redirectedAssemblyName;
         }
 
         #endregion

--- a/AsmSpy.Core/DependencyAnalyzerResult.cs
+++ b/AsmSpy.Core/DependencyAnalyzerResult.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 
 namespace AsmSpy.Core
 {
@@ -20,5 +21,7 @@ namespace AsmSpy.Core
 
         public ICollection<FileInfo> AnalyzedFiles { get; }
         public IDictionary<string, AssemblyReferenceInfo> Assemblies { get; }
+
+        public bool HasMissingAssemblies => Assemblies.Any(x => x.Value.AssemblySource == AssemblySource.NotFound);
     }
 }

--- a/AsmSpy.Core/IDependencyAnalyzerResult.cs
+++ b/AsmSpy.Core/IDependencyAnalyzerResult.cs
@@ -7,5 +7,6 @@ namespace AsmSpy.Core
     {
         ICollection<FileInfo> AnalyzedFiles { get; }
         IDictionary<string, AssemblyReferenceInfo> Assemblies { get; }
+        bool HasMissingAssemblies { get; }
     }
 }

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ AsmSpy
 
 A simple command line tool to view assembly references.
 
-## Install 
+## Install
 
 Install [from Chocolatey package](https://chocolatey.org/packages/asmspy):
 
@@ -31,6 +31,7 @@ It will output a list of all conflicting assembly references. That is where diff
 | dgml | export dependency graph to a dgml file.<br> Supported formats:  -dg \<filename\>, --silent \<filename\> |
 | rsw | Will only analyze assemblies if their referenced assemblies starts with the given value.<br> Supported formats:  -rsw \<string\>, --referencedstartswith \<string\> |
 | i | include subdirectories in search.<br> Supported formats:  -i, --includesub |
+| c | use the binding redirects of the given configuration file (Web.config or App.config) <br> Supported formats: -c|--configurationFile |
 
 ### Examples
 To see a list of all assemblies and all references, just add the 'all' flag:
@@ -64,7 +65,7 @@ The output looks something like this:
 		3.5.0.0 by Microsoft.Web.Mvc
 
 
-You can see that System.Web.Mvc is referenced by 7 assemblies in my bin folder. Some reference 
+You can see that System.Web.Mvc is referenced by 7 assemblies in my bin folder. Some reference
 version 2.0.0.0 and some version 3.0.0.0. I can now resolve any conflicts.
 
 Color coding is used to more easily distinguish any problems.

--- a/README.md
+++ b/README.md
@@ -31,7 +31,8 @@ It will output a list of all conflicting assembly references. That is where diff
 | dgml | export dependency graph to a dgml file.<br> Supported formats:  -dg \<filename\>, --silent \<filename\> |
 | rsw | Will only analyze assemblies if their referenced assemblies starts with the given value.<br> Supported formats:  -rsw \<string\>, --referencedstartswith \<string\> |
 | i | include subdirectories in search.<br> Supported formats:  -i, --includesub |
-| c | use the binding redirects of the given configuration file (Web.config or App.config) <br> Supported formats: -c|--configurationFile |
+| c | use the binding redirects of the given configuration file (Web.config or App.config) <br> Supported formats: -c \<string>, --configurationFile \<string> |
+| f | whether to exit with an error code when AsmSpy detected Assemblies which could not be found <br> Supported formats. -f, --failOnMissing |
 
 ### Examples
 To see a list of all assemblies and all references, just add the 'all' flag:


### PR DESCRIPTION
Here you go :-)

The idea is to start a seperate AppDomain based on the provided ConfigurationFile, run the `ApplyPolicy` on the given AssemblyName and use the result inside the AssemblyList which is kept internally.

That way we save ourselfs from evaluating the bindingRedirects manually.

Also I colorized redirected Assemblys in `DarkGreen` instead of `Green` to have a chance to tell them apart a little bit.

Fixes #54 