### PR TITLE
Do not report System Assembly errors when --nonsystem is given

### DIFF
--- a/AsmSpy.CommandLine/Program.cs
+++ b/AsmSpy.CommandLine/Program.cs
@@ -113,7 +113,7 @@ namespace AsmSpy.CommandLine
                     bindingRedirects.Visualize();
                 }
 
-                if (failOnMissing.HasValue() && result.HasMissingAssemblies)
+                if (failOnMissing.HasValue() && result.MissingAssemblies.Any(x => !skipSystem || !x.IsSystem))
                 {
                     return -1;
                 }

--- a/AsmSpy.Core/DependencyAnalyzerResult.cs
+++ b/AsmSpy.Core/DependencyAnalyzerResult.cs
@@ -21,7 +21,6 @@ namespace AsmSpy.Core
 
         public ICollection<FileInfo> AnalyzedFiles { get; }
         public IDictionary<string, AssemblyReferenceInfo> Assemblies { get; }
-
-        public bool HasMissingAssemblies => Assemblies.Any(x => x.Value.AssemblySource == AssemblySource.NotFound);
+        public IEnumerable<AssemblyReferenceInfo> MissingAssemblies => Assemblies.Where(x => x.Value.AssemblySource == AssemblySource.NotFound).Select(x => x.Value);
     }
 }

--- a/AsmSpy.Core/IDependencyAnalyzerResult.cs
+++ b/AsmSpy.Core/IDependencyAnalyzerResult.cs
@@ -7,6 +7,6 @@ namespace AsmSpy.Core
     {
         ICollection<FileInfo> AnalyzedFiles { get; }
         IDictionary<string, AssemblyReferenceInfo> Assemblies { get; }
-        bool HasMissingAssemblies { get; }
+        IEnumerable<AssemblyReferenceInfo> MissingAssemblies { get; }
     }
 }


### PR DESCRIPTION
This fixes a little incosistency where AsmSpy exits with ErrorCode -1 when System Assemblies could not be found but the --nonsystem option was provided.

This led to situations, where the ErrorCode was -1 even so the Output didn't show any errors.