### PR TITLE
Minor fixes for XML exporter

### DIFF
--- a/AsmSpy.CommandLine/Program.cs
+++ b/AsmSpy.CommandLine/Program.cs
@@ -112,6 +112,7 @@ namespace AsmSpy.CommandLine
                     var export = new XmlExport(result, string.IsNullOrWhiteSpace(xml.Value()) ? Path.Combine(directoryInfo.FullName, "references.xml") : xml.Value(), consoleLogger)
                     {
                         SkipSystem = skipSystem,
+                        OnlyConflicts = onlyConflicts,
                         ReferencedStartsWith = referencedStartsWith.HasValue() ? referencedStartsWith.Value() : string.Empty
                     };
                     export.Visualize();
@@ -144,7 +145,11 @@ namespace AsmSpy.CommandLine
             {
                 Console.WriteLine(cpe.Message);
                 commandLineApplication.ShowHelp();
-                return 0;
+                return -1;
+            }
+            catch (Exception)
+            {
+                return -1;
             }
         }
     }

--- a/AsmSpy.CommandLine/XmlExport.cs
+++ b/AsmSpy.CommandLine/XmlExport.cs
@@ -14,6 +14,7 @@ namespace AsmSpy.CommandLine
 
         public string ReferencedStartsWith { get; set; }
         public bool SkipSystem { get; set; }
+        public bool OnlyConflicts { get; set; }
 
         public XmlExport(IDependencyAnalyzerResult result, string fileName, ILogger logger)
         {
@@ -60,7 +61,7 @@ namespace AsmSpy.CommandLine
                 }
 
                 var assemblyInfos = assemblyGroup.OrderBy(x => x.AssemblyName.Name).ToList();
-                if (assemblyInfos.Count <= 1)
+                if (OnlyConflicts && assemblyInfos.Count <= 1)
                 {
                     if (assemblyInfos.Count == 1 && assemblyInfos[0].AssemblySource == AssemblySource.Local)
                     {
@@ -111,6 +112,7 @@ namespace AsmSpy.CommandLine
                                 using (writer.WriteElementScope("Referer"))
                                 {
                                     writer.WriteAttributeString("Name", referer.AssemblyName.Name);
+                                    writer.WriteAttributeString("Version", referer.AssemblyName.Version.ToString());
                                     writer.WriteAttributeString("FullName", referer.AssemblyName.FullName);
                                 }
                             }


### PR DESCRIPTION
I've not opened an issue for this, but I've made some minor improvements to the XML exporter that I thought might be useful for others. Two of the changes are breaking so do not hesitate to not merge this PR if you think it does too much.

* Add support for only exporting conflicts.
* Export the version of the referer.
* Return `-1` if there was an error parsing arguments.
* Return `-1` if an unhandled exception occurs in `AsmSpy`.

The two last changes ensures that a calling script can detect whether or not something went wrong when calling AsmSpy.