### PR TITLE
Fix to DependencyAnalyzer.MarkReferencedAssemblies to guard against c…

### DIFF
--- a/AsmSpy.Core/DependencyAnalyzer.cs
+++ b/AsmSpy.Core/DependencyAnalyzer.cs
@@ -32,7 +32,7 @@ namespace AsmSpy.Core
             MapAssemblyReferences(result, appDomainWithBindingRedirects, options);
             ResolveNonFileReferences(result, logger);
             FindRootAssemblies(result, logger, rootFileName);
-            MarkRefernecedAssemblies(result);
+            MarkReferencedAssemblies(result);
 
             return result;
         }
@@ -171,7 +171,7 @@ namespace AsmSpy.Core
             }
         }
 
-        private static void MarkRefernecedAssemblies(DependencyAnalyzerResult result)
+        private static void MarkReferencedAssemblies(DependencyAnalyzerResult result)
         {
             foreach(var assembly in result.Roots)
             {
@@ -180,6 +180,11 @@ namespace AsmSpy.Core
             
             void WalkAndMark(IAssemblyReferenceInfo assembly)
             {
+                if (assembly.ReferencedByRoot)
+                {
+                    return;
+                }
+
                 assembly.ReferencedByRoot = true;
                 foreach(var dependency in assembly.References)
                 {


### PR DESCRIPTION
…ircular references. Also corrected spelling of method name.

We utilise a cross-compiled version of parts of the OpenJDK via [IKVM](https://www.ikvm.net/). This (it seems) creates a circular reference between a couple of these assemblies (which runs perfectly fine) but causes asmspy to choke.