### PR TITLE
XmlExport not enabled based on command line option

### DIFF
--- a/AsmSpy.CommandLine/XmlExport.cs
+++ b/AsmSpy.CommandLine/XmlExport.cs
@@ -123,8 +123,8 @@ namespace AsmSpy.CommandLine
             if (xml.HasValue())
             {
                 outputFile = xml.Value();
-				return true;
-			}
+                return true;
+            }
 
             return false;
         }

--- a/AsmSpy.CommandLine/XmlExport.cs
+++ b/AsmSpy.CommandLine/XmlExport.cs
@@ -123,7 +123,9 @@ namespace AsmSpy.CommandLine
             if (xml.HasValue())
             {
                 outputFile = xml.Value();
-            }
+				return true;
+			}
+
             return false;
         }
     }


### PR DESCRIPTION
XmlExport.IsConfigured was not returning true when the command line option value is supplied.