### PR TITLE
List unreferenced files

### DIFF
--- a/AsmSpy.CommandLine/AsmSpy.CommandLine.csproj
+++ b/AsmSpy.CommandLine/AsmSpy.CommandLine.csproj
@@ -65,6 +65,7 @@
     <Compile Include="BindingRedirectExport.cs" />
     <Compile Include="ConsoleLogger.cs" />
     <Compile Include="ConsoleTreeVisualizer.cs" />
+    <Compile Include="ConsoleUnreferencedAssembliesVisualizer.cs" />
     <Compile Include="ConsoleVisualizer.cs" />
     <Compile Include="DgmlExport.cs" />
     <Compile Include="DotExport.cs" />
@@ -90,6 +91,7 @@
     <EmbeddedResource Include="AsmSpy.CommandLine.resx">
       <Generator>ResXFileCodeGenerator</Generator>
       <LastGenOutput>AsmSpy.CommandLine.Designer.cs</LastGenOutput>
+      <SubType>Designer</SubType>
     </EmbeddedResource>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />

--- a/AsmSpy.CommandLine/ConsoleUnreferencedAssembliesVisualizer.cs
+++ b/AsmSpy.CommandLine/ConsoleUnreferencedAssembliesVisualizer.cs
@@ -7,89 +7,89 @@ using System.Linq;
 
 namespace AsmSpy.CommandLine
 {
-	public class ConsoleUnreferencedAssembliesVisualizer : IDependencyVisualizer
-	{
-		private const ConsoleColor AssemblyNotFoundColor = ConsoleColor.Red;
-		private const ConsoleColor AssemblyLocalColor = ConsoleColor.Green;
-		private const ConsoleColor AssemblyLocalRedirectedColor = ConsoleColor.DarkGreen;
-		private const ConsoleColor AssemblyGlobalAssemblyCacheColor = ConsoleColor.Yellow;
-		private const ConsoleColor AssemblyUnknownColor = ConsoleColor.Magenta;
+    public class ConsoleUnreferencedAssembliesVisualizer : IDependencyVisualizer
+    {
+        private const ConsoleColor AssemblyNotFoundColor = ConsoleColor.Red;
+        private const ConsoleColor AssemblyLocalColor = ConsoleColor.Green;
+        private const ConsoleColor AssemblyLocalRedirectedColor = ConsoleColor.DarkGreen;
+        private const ConsoleColor AssemblyGlobalAssemblyCacheColor = ConsoleColor.Yellow;
+        private const ConsoleColor AssemblyUnknownColor = ConsoleColor.Magenta;
 
-		public virtual void Visualize(DependencyAnalyzerResult result, ILogger logger, VisualizerOptions visualizerOptions)
-		{
-			if (result.AnalyzedFiles.Count <= 0)
-			{
-				Console.WriteLine(AsmSpy_CommandLine.No_assemblies_files_found_in_directory);
-				return;
-			}
+        public virtual void Visualize(DependencyAnalyzerResult result, ILogger logger, VisualizerOptions visualizerOptions)
+        {
+            if (result.AnalyzedFiles.Count <= 0)
+            {
+                Console.WriteLine(AsmSpy_CommandLine.No_assemblies_files_found_in_directory);
+                return;
+            }
 
-			Console.WriteLine("Unreferenced Assemblies From Initial Files");
+            Console.WriteLine("Unreferenced Assemblies From Initial Files");
 
-			IEnumerable<AssemblyReferenceInfo> assemblyFiles = 
-				result.Assemblies.Values.Where(x => x.FileName != string.Empty && x.ReferencedBy.Count == 0);
+            IEnumerable<AssemblyReferenceInfo> assemblyFiles = 
+                result.Assemblies.Values.Where(x => x.FileName != string.Empty && x.ReferencedBy.Count == 0);
 
-			foreach (var assembly in assemblyFiles.OrderBy(i => i.AssemblyName.ToString()))
-			{
-				Console.ForegroundColor = GetMainNameColor(assembly);
+            foreach (var assembly in assemblyFiles.OrderBy(i => i.AssemblyName.ToString()))
+            {
+                Console.ForegroundColor = GetMainNameColor(assembly);
 
-				VisualizeAssemblyReferenceInfo(assembly);
+                VisualizeAssemblyReferenceInfo(assembly);
 
-				Console.WriteLine();
-			}
+                Console.WriteLine();
+            }
 
-			Console.ResetColor();
-		}
+            Console.ResetColor();
+        }
 
-		protected virtual ConsoleColor GetMainNameColor(AssemblyReferenceInfo assemblyReferenceInfo)
-		{
-			return AssemblyLocalColor;
-		}
+        protected virtual ConsoleColor GetMainNameColor(AssemblyReferenceInfo assemblyReferenceInfo)
+        {
+            return AssemblyLocalColor;
+        }
 
-		protected virtual void VisualizeAssemblyReferenceInfo(AssemblyReferenceInfo assemblyReferenceInfo)
-		{
-			if (assemblyReferenceInfo == null)
-			{
-				throw new ArgumentNullException(nameof(assemblyReferenceInfo));
-			}
+        protected virtual void VisualizeAssemblyReferenceInfo(AssemblyReferenceInfo assemblyReferenceInfo)
+        {
+            if (assemblyReferenceInfo == null)
+            {
+                throw new ArgumentNullException(nameof(assemblyReferenceInfo));
+            }
 
-			ConsoleColor statusColor;
-			switch (assemblyReferenceInfo.AssemblySource)
-			{
-				case AssemblySource.NotFound:
-					statusColor = AssemblyNotFoundColor;
-					break;
-				case AssemblySource.Local:
-					statusColor = AssemblyLocalColor;
-					break;
-				case AssemblySource.GlobalAssemblyCache:
-					statusColor = AssemblyGlobalAssemblyCacheColor;
-					break;
-				case AssemblySource.Unknown:
-					statusColor = AssemblyUnknownColor;
-					break;
-				default:
-					throw new InvalidEnumArgumentException(AsmSpy_CommandLine.Invalid_AssemblySource);
-			}
-			Console.ForegroundColor = statusColor;
-			Console.WriteLine(AsmSpy_CommandLine.ConsoleVisualizer_VisualizeAssemblyReferenceInfo____0_, assemblyReferenceInfo.AssemblyName);
-			Console.Write(AsmSpy_CommandLine.Source_, assemblyReferenceInfo.AssemblySource);
-			if (assemblyReferenceInfo.AssemblySource != AssemblySource.NotFound)
-			{
-				Console.WriteLine(AsmSpy_CommandLine.Location_, assemblyReferenceInfo.ReflectionOnlyAssembly.Location);
-			}
-			else
-			{
-				Console.WriteLine();
-			}
-		}
+            ConsoleColor statusColor;
+            switch (assemblyReferenceInfo.AssemblySource)
+            {
+                case AssemblySource.NotFound:
+                    statusColor = AssemblyNotFoundColor;
+                    break;
+                case AssemblySource.Local:
+                    statusColor = AssemblyLocalColor;
+                    break;
+                case AssemblySource.GlobalAssemblyCache:
+                    statusColor = AssemblyGlobalAssemblyCacheColor;
+                    break;
+                case AssemblySource.Unknown:
+                    statusColor = AssemblyUnknownColor;
+                    break;
+                default:
+                    throw new InvalidEnumArgumentException(AsmSpy_CommandLine.Invalid_AssemblySource);
+            }
+            Console.ForegroundColor = statusColor;
+            Console.WriteLine(AsmSpy_CommandLine.ConsoleVisualizer_VisualizeAssemblyReferenceInfo____0_, assemblyReferenceInfo.AssemblyName);
+            Console.Write(AsmSpy_CommandLine.Source_, assemblyReferenceInfo.AssemblySource);
+            if (assemblyReferenceInfo.AssemblySource != AssemblySource.NotFound)
+            {
+                Console.WriteLine(AsmSpy_CommandLine.Location_, assemblyReferenceInfo.ReflectionOnlyAssembly.Location);
+            }
+            else
+            {
+                Console.WriteLine();
+            }
+        }
 
-		CommandOption unreferencedAssembliesOption;
+        CommandOption unreferencedAssembliesOption;
 
-		public void CreateOption(CommandLineApplication commandLineApplication)
-		{
-			unreferencedAssembliesOption = commandLineApplication.Option("-ua|--unref", "Show unreferenced assembly files on console.", CommandOptionType.NoValue);
-		}
+        public void CreateOption(CommandLineApplication commandLineApplication)
+        {
+            unreferencedAssembliesOption = commandLineApplication.Option("-ua|--unref", "Show unreferenced assembly files on console.", CommandOptionType.NoValue);
+        }
 
-		public bool IsConfigured() => unreferencedAssembliesOption.HasValue();
-	}
+        public bool IsConfigured() => unreferencedAssembliesOption.HasValue();
+    }
 }

--- a/AsmSpy.CommandLine/ConsoleUnreferencedAssembliesVisualizer.cs
+++ b/AsmSpy.CommandLine/ConsoleUnreferencedAssembliesVisualizer.cs
@@ -1,0 +1,95 @@
+﻿using AsmSpy.Core;
+using Microsoft.Extensions.CommandLineUtils;
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Linq;
+
+namespace AsmSpy.CommandLine
+{
+	public class ConsoleUnreferencedAssembliesVisualizer : IDependencyVisualizer
+	{
+		private const ConsoleColor AssemblyNotFoundColor = ConsoleColor.Red;
+		private const ConsoleColor AssemblyLocalColor = ConsoleColor.Green;
+		private const ConsoleColor AssemblyLocalRedirectedColor = ConsoleColor.DarkGreen;
+		private const ConsoleColor AssemblyGlobalAssemblyCacheColor = ConsoleColor.Yellow;
+		private const ConsoleColor AssemblyUnknownColor = ConsoleColor.Magenta;
+
+		public virtual void Visualize(DependencyAnalyzerResult result, ILogger logger, VisualizerOptions visualizerOptions)
+		{
+			if (result.AnalyzedFiles.Count <= 0)
+			{
+				Console.WriteLine(AsmSpy_CommandLine.No_assemblies_files_found_in_directory);
+				return;
+			}
+
+			Console.WriteLine("Unreferenced Assemblies From Initial Files");
+
+			IEnumerable<AssemblyReferenceInfo> assemblyFiles = 
+				result.Assemblies.Values.Where(x => x.FileName != string.Empty && x.ReferencedBy.Count == 0);
+
+			foreach (var assembly in assemblyFiles.OrderBy(i => i.AssemblyName.ToString()))
+			{
+				Console.ForegroundColor = GetMainNameColor(assembly);
+
+				VisualizeAssemblyReferenceInfo(assembly);
+
+				Console.WriteLine();
+			}
+
+			Console.ResetColor();
+		}
+
+		protected virtual ConsoleColor GetMainNameColor(AssemblyReferenceInfo assemblyReferenceInfo)
+		{
+			return AssemblyLocalColor;
+		}
+
+		protected virtual void VisualizeAssemblyReferenceInfo(AssemblyReferenceInfo assemblyReferenceInfo)
+		{
+			if (assemblyReferenceInfo == null)
+			{
+				throw new ArgumentNullException(nameof(assemblyReferenceInfo));
+			}
+
+			ConsoleColor statusColor;
+			switch (assemblyReferenceInfo.AssemblySource)
+			{
+				case AssemblySource.NotFound:
+					statusColor = AssemblyNotFoundColor;
+					break;
+				case AssemblySource.Local:
+					statusColor = AssemblyLocalColor;
+					break;
+				case AssemblySource.GlobalAssemblyCache:
+					statusColor = AssemblyGlobalAssemblyCacheColor;
+					break;
+				case AssemblySource.Unknown:
+					statusColor = AssemblyUnknownColor;
+					break;
+				default:
+					throw new InvalidEnumArgumentException(AsmSpy_CommandLine.Invalid_AssemblySource);
+			}
+			Console.ForegroundColor = statusColor;
+			Console.WriteLine(AsmSpy_CommandLine.ConsoleVisualizer_VisualizeAssemblyReferenceInfo____0_, assemblyReferenceInfo.AssemblyName);
+			Console.Write(AsmSpy_CommandLine.Source_, assemblyReferenceInfo.AssemblySource);
+			if (assemblyReferenceInfo.AssemblySource != AssemblySource.NotFound)
+			{
+				Console.WriteLine(AsmSpy_CommandLine.Location_, assemblyReferenceInfo.ReflectionOnlyAssembly.Location);
+			}
+			else
+			{
+				Console.WriteLine();
+			}
+		}
+
+		CommandOption unreferencedAssembliesOption;
+
+		public void CreateOption(CommandLineApplication commandLineApplication)
+		{
+			unreferencedAssembliesOption = commandLineApplication.Option("-ua|--unref", "Show unreferenced assembly files on console.", CommandOptionType.NoValue);
+		}
+
+		public bool IsConfigured() => unreferencedAssembliesOption.HasValue();
+	}
+}

--- a/AsmSpy.CommandLine/Program.cs
+++ b/AsmSpy.CommandLine/Program.cs
@@ -167,7 +167,8 @@ namespace AsmSpy.CommandLine
             new DgmlExport(),
             new XmlExport(),
             new DotExport(),
-            new BindingRedirectExport()
+            new BindingRedirectExport(),
+			new ConsoleUnreferencedAssembliesVisualizer(), 
         };
     }
 }

--- a/AsmSpy.CommandLine/Program.cs
+++ b/AsmSpy.CommandLine/Program.cs
@@ -168,7 +168,7 @@ namespace AsmSpy.CommandLine
             new XmlExport(),
             new DotExport(),
             new BindingRedirectExport(),
-			new ConsoleUnreferencedAssembliesVisualizer(), 
+            new ConsoleUnreferencedAssembliesVisualizer(), 
         };
     }
 }


### PR DESCRIPTION
Added a visualizer, that writes to the console, based on the initial list of files (not dynamic dependencies), those Assemblies that are not directly referenced by any other Assemblies.

This can give false positives on Assemblies that are only loaded/used via reflection.