### PR TITLE
Use RedirectedAssemblyName when calling Assembly.ReflectionOnlyLoad

### DIFF
--- a/AsmSpy.Core/DependencyAnalyzer.cs
+++ b/AsmSpy.Core/DependencyAnalyzer.cs
@@ -106,7 +106,7 @@ namespace AsmSpy.Core
             {
                 try
                 {
-                    assembly.ReflectionOnlyAssembly = Assembly.ReflectionOnlyLoad(assembly.AssemblyName.FullName);
+                    assembly.ReflectionOnlyAssembly = Assembly.ReflectionOnlyLoad(assembly.RedirectedAssemblyName?.FullName ?? assembly.AssemblyName.FullName);
                     assembly.AssemblySource = assembly.ReflectionOnlyAssembly.GlobalAssemblyCache
                         ? AssemblySource.GlobalAssemblyCache
                         : AssemblySource.Unknown;


### PR DESCRIPTION
`Assembly.ReflectionOnlyLoad` does not honor assembly binding redirects. (See https://web.archive.org/web/20171020080642/http://blogs.microsoft.co.il/sasha/2010/06/09/assemblyreflectiononlyload-ignores-assembly-binding-redirects/)

This is specifically bad because there are some automatic binding redirects applied by microsoft internally. One example is `System.IO.Compression` (and I think another one is `System.Net.Http`). Even though there is no manual `<bindingRedirect>` defined, calling `AppDomain.ApplyPolicy` on those assemblies will return remapped assemblies.

Later on the in process, AsmSpy tries to find the correct Assembly based on the original AssemblyName and will not find anything.

In "real life" everything works, because `Assembly.Load` will actually find the assemblies, but `Assembly.ReflectionOnlyLoad` will not.
Therefor - as we do know the redirected assembly name, we probe on this before falling back to the orignal name, if there is no redirected one.