### PR TITLE
catch FileLoadException

### DIFF
--- a/AsmSpy.Core/DependencyAnalyzer.cs
+++ b/AsmSpy.Core/DependencyAnalyzer.cs
@@ -135,6 +135,11 @@ namespace AsmSpy.Core
                         assembly.AssemblySource = AssemblySource.NotFound;
                     }
                 }
+                catch (FileLoadException)
+                {
+                    logger.LogError($"Failed to load {assembly.AssemblyName.Name} {assembly.AssemblyName.Version.ToString()}");
+                    assembly.AssemblySource = AssemblySource.NotFound;
+                }
             }
         }
 


### PR DESCRIPTION
FileLoadException could be thrown by Assembly.ReflectionOnlyLoad for some reason.
The fix makes the application alive for it.