### PR TITLE
Add tree depth limitation option and label option

### DIFF
--- a/AsmSpy.CommandLine/Program.cs
+++ b/AsmSpy.CommandLine/Program.cs
@@ -8,6 +8,7 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
 using System.Linq;
+using System.Text;
 
 namespace AsmSpy.CommandLine
 {
@@ -15,6 +16,8 @@ namespace AsmSpy.CommandLine
     {
         public static int Main(string[] args)
         {
+            Console.OutputEncoding = Encoding.Unicode;
+
             var commandLineApplication = new CommandLineApplication(throwOnUnexpectedArg: true);
             var directoryOrFile = commandLineApplication.Argument("directoryOrFile", "The directory to search for assemblies or file path to a single assembly");
 

--- a/README.md
+++ b/README.md
@@ -35,6 +35,8 @@ It will output a list of all conflicting assembly references. That is where diff
 | rsw | Will only analyze assemblies if their referenced assemblies starts with the given value.<br> Supported formats:  -rsw \<string\>, --referencedstartswith \<string\> |
 | e | Will exclude assemblies if they start with the given value. This option can be provided multiple times.<br> Supported formats:  -e \<string\>, --exclude \<string\> |
 | tree | Write a dependency tree to the console.<br>Supported formats: -tr --tree |
+| treedepth | Limit tree depth (in compbinaison with --tree). Supported formats : -trd \<int\> --treedepth \<int\> |
+| treelabel | Add [Level n] label in tree view of dependencies. Supported formats -trl --treelabel |
 | i | Include subdirectories in search.<br> Supported formats:  -i, --includesub |
 | c | Use the binding redirects of the given configuration file (Web.config or App.config) <br> Supported formats: -c \<string>, --configurationFile \<string> |
 | f | Whether to exit with an error code when AsmSpy detected Assemblies which could not be found <br> Supported formats. -f, --failOnMissing |


### PR DESCRIPTION
I added an option (--treedepth or -trd) to limit the depth of the tree view. That means that if treedepth is 3, it stops walking dependencies pass this level.

Another option is --treelable (or -trl) to add a label indicating the level in the tree. Exemple of the result :
```
└──[LEVEL 0] AsmSpy.Core.Tests 1.0.0.0
    ├──[LEVEL 1] mscorlib 4.0.0.0
    ├──[LEVEL 1] xunit.abstractions 2.0.0.0
    │  └──[LEVEL 2] mscorlib 4.0.0.0
    ├──[LEVEL 1] AsmSpy.Core 1.2.0.0
    │  ├──[LEVEL 2] mscorlib 4.0.0.0
    │  └──[LEVEL 2] System.Core 4.0.0.0
    ├──[LEVEL 1] xunit.core 2.4.1.0
```
I also setted the console encoding to UTF8.  It was usefull in my case because I call asmspy from a powershell script and send the result to a text file. Not sure if you can have counter indication about this,  I don't see any myself.

Thank you for your work, this project is very usefull.
